### PR TITLE
Pulsar 1.5 support

### DIFF
--- a/exporter.json
+++ b/exporter.json
@@ -6,7 +6,7 @@
     "organization": "Supernova",
     "homepage": "https://supernova.io",
     "source_dir": "src",
-    "version": "1.0.3",
+    "version": "1.1",
     "config": {
         "sources": "sources.json",
         "output": "output.json",

--- a/src/borders.pr
+++ b/src/borders.pr
@@ -6,7 +6,7 @@ and their value rendered using `rendered-border` blueprint
 
 *}
 :root {
-{[ for token in @ds.tokensByType("Border") ]}
+{[ for token in ds.tokensByType("Border") ]}
     {[ inject "rendered-token-var" context token /]}
     
 

--- a/src/colors.pr
+++ b/src/colors.pr
@@ -6,7 +6,7 @@ and their value rendered using `rendered-color` blueprint
 
 *}
 :root {
-{[ for token in @ds.tokensByType("Color") ]}
+{[ for token in ds.tokensByType("Color") ]}
     {[ inject "rendered-token-var" context token /]}
     
 

--- a/src/gradients.pr
+++ b/src/gradients.pr
@@ -6,7 +6,7 @@ and their value rendered using `gradient-color` blueprint
 
 *}
 :root {
-{[ for token in @ds.tokensByType("Gradient") ]}
+{[ for token in ds.tokensByType("Gradient") ]}
     {[ inject "rendered-token-var" context token /]}
     
 

--- a/src/main-renderers/reference-wrapper.pr
+++ b/src/main-renderers/reference-wrapper.pr
@@ -18,7 +18,7 @@ Note: Token is passed as `context` property because it is injected
 
 /* description */
 *}
-{[ if @compare.null(context.referencedToken) ]}
-{{#body}}
-{[else]}
+{[ if !context.referencedToken ]}
+{{ #body }}
+{[ else ]}
 var(--{[ inject "rendered-name" context context.referencedToken /]}){[/]}

--- a/src/main-renderers/rendered-description.pr
+++ b/src/main-renderers/rendered-description.pr
@@ -20,6 +20,7 @@ Rendered as:
 
 /* description */
 *}
-{[ if @boolean.not(@compare.empty(context.description)) ]}
+{[ log context.description /]}
+{[ if (context.description && context.description.count() > 0) ]}
 /* {{ context.description.replacing("*/", "* /") }} */
 {[/]}

--- a/src/main-renderers/rendered-description.pr
+++ b/src/main-renderers/rendered-description.pr
@@ -20,7 +20,6 @@ Rendered as:
 
 /* description */
 *}
-{[ log context.description /]}
 {[ if (context.description && context.description.count() > 0) ]}
 /* {{ context.description.replacing("*/", "* /") }} */
 {[/]}

--- a/src/main-renderers/rendered-name.pr
+++ b/src/main-renderers/rendered-name.pr
@@ -24,7 +24,7 @@ Rendered as:
 [group1][group2][...][name];
 
 *}
-{[ let tokenGroup = @ds.tokenGroupContainingTokenId(context.id) /]}
+{[ let tokenGroup = ds.tokenGroupContainingTokenId(context.id) /]}
 {[ let prefix = "" /]}
 {[ switch context.tokenType ]}
 {[ case "Color" ]}{[ prefix = behavior.colorTokenPrefix /]}
@@ -35,5 +35,5 @@ Rendered as:
 {[ case "Gradient" ]}{[ prefix = behavior.gradientTokenPrefix /]}  
 {[ default ]}{[ prefix = "" /]}  
 {[/]}
-{[ let tokenName = @js.readableVariableName(context, tokenGroup, prefix) /]}
+{[ let tokenName = readableVariableName(context, tokenGroup, prefix) /]}
 {{ tokenName }}

--- a/src/main-renderers/rendered-token-class.pr
+++ b/src/main-renderers/rendered-token-class.pr
@@ -29,7 +29,7 @@ Rendered as:
 {[ inject "rendered-description" context token /]}
 .{[ inject "rendered-name" context token /]} 
 
-{[ for alias in @js.findAliases(context.token, context.allTokens) ]}
+{[ for alias in (findAliases(context.token, context.allTokens)) ]}
 , {[ inject "rendered-description" context alias /]}
 .{[ inject "rendered-name" context alias /]}
 {[/]} {

--- a/src/measures.pr
+++ b/src/measures.pr
@@ -6,7 +6,7 @@ and their value rendered using `rendered-measure` blueprint
 
 *}
 :root {
-{[ for token in @ds.tokensByType("Measure") ]}
+{[ for token in ds.tokensByType("Measure") ]}
     {[ inject "rendered-token-var" context token /]}
     
 

--- a/src/shadows.pr
+++ b/src/shadows.pr
@@ -6,7 +6,7 @@ and their value rendered using `shadow-color` blueprint
 
 *}
 :root {
-{[ for token in @ds.tokensByType("Shadow") ]}
+{[ for token in ds.tokensByType("Shadow") ]}
     {[ inject "rendered-token-var" context token /]}
     
 

--- a/src/token-renderers/rendered-color.pr
+++ b/src/token-renderers/rendered-color.pr
@@ -27,7 +27,7 @@ Rendered as:
 
 *}
 {[ inject "reference-wrapper" context context ]}
-{[ if @compare.lessThan(context.a, 255) ]}
+{[ if (context.a < 255) ]}
 #{{ context.hex }}
 {[ else ]}
 #{{ context.hex.substring(0, 6) }}

--- a/src/token-renderers/rendered-gradient.pr
+++ b/src/token-renderers/rendered-gradient.pr
@@ -38,15 +38,15 @@ linear-gradient(
 *}
 {[ inject "reference-wrapper" context context ]}
 {[ let gradientType = "linear-gradient" /]}
-{[ let gradientDirection = @js.gradientAngle(context.from, context.to).rounded(2).toString().suffixed("deg") /]}
-{[ if @compare.equals(context.type, "Radial") ]}
+{[ let gradientDirection = gradientAngle(context.from, context.to).rounded(2).toString().suffixed("deg") /]}
+{[ if (context.type === "Radial") ]}
   {[ set "gradientType" = "radial-gradient" /]}
   {[ set "gradientDirection" = "circle at center" /]}
 {[/]}
 {{ gradientType }}(
   {{ gradientDirection }},
   {[ for stop in context.stops ]}
-{[ inject "rendered-color" context stop.color /]} {{ stop.position.multipliedBy(100).rounded(1) }}%{[ if @boolean.not(#last) ]}, {[/]}
+{[ inject "rendered-color" context stop.color /]} {{ (stop.position * 100).rounded(1) }}%{[ if !(#last) ]}, {[/]}
   
   {[/]}
 )

--- a/src/token-renderers/rendered-gradient.pr
+++ b/src/token-renderers/rendered-gradient.pr
@@ -40,8 +40,8 @@ linear-gradient(
 {[ let gradientType = "linear-gradient" /]}
 {[ let gradientDirection = gradientAngle(context.from, context.to).rounded(2).toString().suffixed("deg") /]}
 {[ if (context.type === "Radial") ]}
-  {[ set "gradientType" = "radial-gradient" /]}
-  {[ set "gradientDirection" = "circle at center" /]}
+  {[ "gradientType" = "radial-gradient" /]}
+  {[ "gradientDirection" = "circle at center" /]}
 {[/]}
 {{ gradientType }}(
   {{ gradientDirection }},

--- a/src/token-renderers/rendered-measure.pr
+++ b/src/token-renderers/rendered-measure.pr
@@ -20,11 +20,11 @@ Note: Value is passed as `context` property because it is injected
 {[ let unit = "px" /]}
 {[ switch context.unit ]}
 {[ case "Points"]}
-{[ set unit = "pt"/]}
+{[ unit = "pt"/]}
 {[ case "Percent"]}
-{[ set unit = "%"/]}
+{[ unit = "%"/]}
 {[ case "Ems"]}
-{[ set unit = "em"/]}
+{[ unit = "em"/]}
 {[/]}
 {{ context.measure }}{{ unit }}
 {[/]}

--- a/src/token-renderers/rendered-typography.pr
+++ b/src/token-renderers/rendered-typography.pr
@@ -54,7 +54,7 @@ Rendered as:
 
 {[ let fontStyle = "normal" /]}
 {[ if ds.isFontItalic(context.font) ]}
-  {[ set fontStyle = "italic" /]}
+  {[ fontStyle = "italic" /]}
 {[/]}
 font-family: "{{ context.font.family }}";
 font-style: {{ fontStyle }};

--- a/src/token-renderers/rendered-typography.pr
+++ b/src/token-renderers/rendered-typography.pr
@@ -53,18 +53,18 @@ Rendered as:
 *}
 
 {[ let fontStyle = "normal" /]}
-{[ if @ds.fonts.isItalic(context.font) ]}
+{[ if ds.isFontItalic(context.font) ]}
   {[ set fontStyle = "italic" /]}
 {[/]}
 font-family: "{{ context.font.family }}";
 font-style: {{ fontStyle }};
-font-weight: {{ @ds.fonts.weight(context.font) }};
+font-weight: {{ ds.fontWeight(context.font) }};
 font-size: {[ inject "rendered-measure" context context.fontSize /]};
-{[ if @compare.nonnull(context.lineHeight) ]}
+{[ if context.lineHeight ]}
 line-height: {[ inject "rendered-measure" context context.lineHeight /]};
 {[/]}
-letter-spacing: {[if @compare.equals(context.letterSpacing.unit, "Percent") ]} 
-{{ context.letterSpacing.measure.dividedBy(100).rounded(2) }}em;
+letter-spacing: {[if (context.letterSpacing.unit === "Percent") ]} 
+{{ (context.letterSpacing.measure / 100).rounded(2) }}em;
 {[ else ]}
 {[ inject "rendered-measure" context context.letterSpacing /]};
 {[/]}

--- a/src/typography.pr
+++ b/src/typography.pr
@@ -5,10 +5,10 @@ Tokens are named by their group path and then name,
 and their value rendered using `rendered-color` blueprint
 
 *}
-{[ const allTokens = @ds.tokensByType("Typography") /]}
+{[ const allTokens = ds.tokensByType("Typography") /]}
 {[ for token in allTokens ]}
-{[ if @compare.null(token.referencedToken) ]}
-{[ inject "rendered-token-class" context @init.dictionary().add("token", token).add("allTokens", allTokens) /]}    
+{[ if !token.referencedToken ]}
+{[ inject "rendered-token-class" context { "token": token, "allTokens": allTokens } /]}    
 
 
 {[/]}


### PR DESCRIPTION
This PR adds support for Pulsar 1.5

- All javascript calls now treated as top-level functions (no more `@js.` needed and will throw error if used) so all are reworked
- DS accessors are now proper methods on top-level `ds` object, so everything was reworked for this and autocomplete now properly works for those as well
- All ds methods are now actual methods, and can't have extra `.` inside it, so that was removed (for example, `@ds.fonts.isItalic` is now actually `ds.isFontItalic()`)
- Expressions have been simplified and syntax reworked to be aligned with new Pulsar, which follows JS syntax closely now
- Complex expressions inside flows must be surrounded with `()`, but expressions inside `{{ }}` don't need this, so reworked as well
- Added shorthands and object support, so you can use `{}` and `[]` to create empty objects and arrays, and all methods used previously to init etc. were removed
- `self` is `this` to align with javascript, and `self` is no longer available as global property

- Version of exporter bumped to next minor


Note for reviewer:
This PR CAN'T be merged and exporter run before Pulsar is merged to your environments, please don't merge it yourself.